### PR TITLE
Potential fix for code scanning alert no. 2: Potential use after free

### DIFF
--- a/linux/imgRead.c
+++ b/linux/imgRead.c
@@ -57,13 +57,14 @@ int ProcessImage(char* filename){
 			//heap buffer overflow
 			memcpy(buff1,img.data,sizeof(img.data));
 			free(buff1);
+			buff1 = NULL;
 			//double free	
 			if (size1%2==0){
-				free(buff1);
+				// free(buff1); // buff1 is already freed and set to NULL
 			}
 			else{
 				//use after free
-				if(size1%3 == 0){
+				if(size1%3 == 0 && buff1 != NULL){
 					buff1[0]='a';
 				}
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/vichuzlyf/Damn_Vulnerable_C_Program/security/code-scanning/2](https://github.com/vichuzlyf/Damn_Vulnerable_C_Program/security/code-scanning/2)

To fix the problem, we need to ensure that `buff1` is not accessed after it has been freed. One way to achieve this is to set `buff1` to `NULL` immediately after freeing it. This way, any subsequent access to `buff1` can be detected as an error (e.g., by checking if `buff1` is `NULL` before accessing it). This approach maintains the existing functionality while preventing the use-after-free error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
